### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-vulnerabilities.yml
+++ b/.github/workflows/check-vulnerabilities.yml
@@ -1,4 +1,6 @@
 name: 'Package Audit'
+permissions:
+    contents: read
 on:
     pull_request:
         branches: ['main']


### PR DESCRIPTION
Potential fix for [https://github.com/nashtech-garage/nt-sketchbook/security/code-scanning/1](https://github.com/nashtech-garage/nt-sketchbook/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided code, the workflow only needs to read repository contents to check out the code and audit dependencies. Therefore, the `permissions` block should be set to `contents: read`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, as there is only one job (`audit`) in this workflow. This ensures that the `GITHUB_TOKEN` is limited to the least privilege necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
