### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -1,4 +1,6 @@
 name: 'Code Check '
+permissions:
+    contents: read
 
 on:
     pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nashtech-garage/nt-sketchbook/security/code-scanning/2](https://github.com/nashtech-garage/nt-sketchbook/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Since the workflow only performs read-only operations, the minimal permission `contents: read` should suffice. This ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block should be added immediately after the `name` field at the top of the file. No additional changes to the workflow steps are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
